### PR TITLE
Fix Homey Pro (Early 2023) crash

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Homey = require('homey');
-const Util = require('/lib/util.js');
+const Util = require('./lib/util.js');
 const tinycolor = require('tinycolor2');
 
 class YeelightApp extends Homey.App {


### PR DESCRIPTION
Homey Pro (Early 2023) uses Docker containers to run apps. Paths are not chrooted to `/app/`, so absolute paths won't resolve.